### PR TITLE
Adding mediaArtistEquals and mediaAlbumNameEquals options to mediaArtworkOverrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ mediaArtworkOverrides: # Show your own selected artwork if certain rules match
   - mediaTitleEquals: p4malmo-aac-192
     imageUrl: >-
       https://mytuner.global.ssl.fastly.net/media/tvos_radios/2BDTPrpMbn_cTdteqo.jpg
+  - mediaArtistEquals: Metallica
+    imageUrl: >-
+      https://mytuner.global.ssl.fastly.net/media/tvos_radios/2BDTPrpMbn_cTdteqo.jpg
+  - mediaAlbumNameEquals: "Master of Puppets"
+    imageUrl: >-
+      https://mytuner.global.ssl.fastly.net/media/tvos_radios/2BDTPrpMbn_cTdteqo.jpg
   - mediaChannelEquals: "Sky Radio Smooth Hits"
     imageUrl: https://cdn-icons-png.flaticon.com/512/4108/4108794.png
   - ifMissing: true # ifMissing will only be used if none of the "Equals" overrides above resulted in a match 

--- a/src/editor/artwork-override-editor.ts
+++ b/src/editor/artwork-override-editor.ts
@@ -15,6 +15,14 @@ class ArtworkOverrideEditor extends BaseEditor {
         type: 'string',
       },
       {
+        name: 'mediaArtistEquals',
+        type: 'string',
+      },
+      {
+        name: 'mediaAlbumNameEquals',
+        type: 'string',
+      },
+      {
         name: 'mediaContentIdEquals',
         type: 'string',
       },

--- a/src/editor/artwork-overrides-editor.ts
+++ b/src/editor/artwork-overrides-editor.ts
@@ -23,6 +23,8 @@ class ArtworkOverridesEditor extends BaseEditor {
               ${items?.map((pg, index) => {
                 const itemName =
                   pg.mediaTitleEquals ||
+                  pg.mediaArtistEquals ||
+                  pg.mediaAlbumNameEquals ||
                   pg.mediaContentIdEquals ||
                   pg.mediaChannelEquals ||
                   (pg.ifMissing && 'if missing') ||

--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -68,6 +68,8 @@ export class Player extends LitElement {
       let override = overrides.find(
         (value) =>
           (media_title && media_title === value.mediaTitleEquals) ||
+          (media_artist && media_artist === value.mediaArtistEquals) ||
+          (media_album_name && media_album_name === value.mediaAlbumNameEquals) ||
           (media_channel && media_channel === value.mediaChannelEquals) ||
           (media_content_id && media_content_id === value.mediaContentIdEquals),
       );

--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -60,7 +60,7 @@ export class Player extends LitElement {
 
   private getArtworkImage() {
     const prefix = this.config.artworkHostname || '';
-    const { media_title, media_content_id, media_channel, entity_picture } = this.activePlayer.attributes;
+    const { media_title, media_artist, media_album_name, media_content_id, media_channel, entity_picture } = this.activePlayer.attributes;
     let entityImage = entity_picture ? prefix + entity_picture : entity_picture;
     let sizePercentage = undefined;
     const overrides = this.config.mediaArtworkOverrides;

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export interface CardConfig extends LovelaceCardConfig {
 export interface MediaArtworkOverride {
   ifMissing?: boolean;
   mediaTitleEquals?: string;
+  mediaArtistEquals?: string;
+  mediaAlbumNameEquals?: string;
   mediaContentIdEquals?: string;
   mediaChannelEquals?: string;
   imageUrl?: string;


### PR DESCRIPTION

We use this card on a couple of panels around the house and we have little kids. Even though in Spotify you can filter explicit content, that doesn't apply to album covers, so having more broad options like artist and album will help hiding such covers.