### PR TITLE
Support entity_picture_local for Music Assistant integration

### DIFF
--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -60,9 +60,11 @@ export class Player extends LitElement {
 
   private getArtworkImage() {
     const prefix = this.config.artworkHostname || '';
-    const { media_title, media_artist, media_album_name, media_content_id, media_channel, entity_picture } =
+    const { media_title, media_artist, media_album_name, media_content_id, media_channel, entity_picture, entity_picture_local, app_id } =
       this.activePlayer.attributes;
     let entityImage = entity_picture ? prefix + entity_picture : entity_picture;
+    if (app_id === 'music_assistant') {
+  entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture_local;}
     let sizePercentage = undefined;
     const overrides = this.config.mediaArtworkOverrides;
     if (overrides) {

--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -64,7 +64,8 @@ export class Player extends LitElement {
       this.activePlayer.attributes;
     let entityImage = entity_picture ? prefix + entity_picture : entity_picture;
     if (app_id === 'music_assistant') {
-  entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture_local;}
+      entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture_local;
+    }
     let sizePercentage = undefined;
     const overrides = this.config.mediaArtworkOverrides;
     if (overrides) {


### PR DESCRIPTION
Music Assistant media_player entities store local album art in the entity_picture_local attribute. If the dashboard displaying the card is a local only dashboard referencing this attribute will display the album art for Music Assistant entities.