### PR TITLE
Fix entity_picture_local for Music Assistant integration

### DIFF
--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -63,8 +63,8 @@ export class Player extends LitElement {
     const { media_title, media_artist, media_album_name, media_content_id, media_channel, entity_picture, entity_picture_local, app_id } =
       this.activePlayer.attributes;
     let entityImage = entity_picture ? prefix + entity_picture : entity_picture;
-    if (app_id === 'music_assistant' && entity_picture_local) {
-      entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture_local;
+    if (app_id === 'music_assistant') {
+      entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture;
     }
     let sizePercentage = undefined;
     const overrides = this.config.mediaArtworkOverrides;

--- a/src/sections/player.ts
+++ b/src/sections/player.ts
@@ -63,7 +63,7 @@ export class Player extends LitElement {
     const { media_title, media_artist, media_album_name, media_content_id, media_channel, entity_picture, entity_picture_local, app_id } =
       this.activePlayer.attributes;
     let entityImage = entity_picture ? prefix + entity_picture : entity_picture;
-    if (app_id === 'music_assistant') {
+    if (app_id === 'music_assistant' && entity_picture_local) {
       entityImage = entity_picture_local ? prefix + entity_picture_local : entity_picture_local;
     }
     let sizePercentage = undefined;


### PR DESCRIPTION
Fix regression introduced in PR #647 which introduced support for the `entity_picture_local` attribute used with local-only dashboards. This code checks whether `entity_picture_local` is populated at all, and falls back to `entity_picture` if not. This has been tested with version 8.7.0 in Google Chromium/Mozilla Firefox on Arch Linux running KDE Plasma 6 (tested also with Windows 11 and the Android Home Assistant app)