### PR TITLE
Fix for volumeEntityID

### DIFF
--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -128,8 +128,7 @@ export default class Store {
     const hassWithEntities = hass as HomeAssistantWithEntities;
     const filtered = Object.values(hass.states).filter((hassEntity) => {
       if (hassEntity.entity_id.includes('media_player')) {
-        // Always include the volume entity if allowPlayerVolumeEntityOutsideOfGroup is set
-        if (this.config.allowPlayerVolumeEntityOutsideOfGroup && hassEntity.entity_id === volumeEntityId) {
+        if (this.config.allowPlayerVolumeEntityOutsideOfGroup && hassEntity.entity_id === this.config.player?.volumeEntityId) {
           return true;
         }
         if (isSonosCard(this.config)) {


### PR DESCRIPTION
Setting the Volume Entity ID in the player to always be used was being ignored even if allowPlayerVolumeEntityOutsideOfGroup  was set to true. This fixes that. https://github.com/punxaphil/maxi-media-player/issues/176