### PR TITLE
Respect zero volume in predefined groups

### DIFF
--- a/src/services/media-control-service.ts
+++ b/src/services/media-control-service.ts
@@ -31,7 +31,7 @@ export default class MediaControlService {
   async activatePredefinedGroup(pg: PredefinedGroup) {
     for (const pgp of pg.entities) {
       const volume = pgp.volume ?? pg.volume;
-      if (volume) {
+      if (volume !== undefined) {
         await this.volumeSetSinglePlayer(pgp.player, volume);
       }
       if (pg.unmuteWhenGrouped) {


### PR DESCRIPTION
Fixes predefined group volume handling so that if volume is 0, it's applied correctly.

Previously, volume 0 was skipped because the check treated it as a falsy value, even though the editor allows 0 as a valid volume.